### PR TITLE
Log query string to query_string hash key

### DIFF
--- a/lib/rack/logstasher/logger.rb
+++ b/lib/rack/logstasher/logger.rb
@@ -18,10 +18,10 @@ module Rack
         data = {
           :method => env["REQUEST_METHOD"],
           :path => env["PATH_INFO"],
+          :query_string => env["QUERY_STRING"],
           :status => status.to_i,
           :duration => duration_in_ms(began_at, now).round(2),
           :remote_addr => env['REMOTE_ADDR'],
-          :parameters => env["QUERY_STRING"],
           :request => request_line(env),
           :length => extract_content_length(response_headers)
         }

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -26,7 +26,7 @@ describe "Logger" do
 
       expect(fields['method']).to eq('GET')
       expect(fields['path']).to eq('/foo')
-      expect(fields['parameters']).to eq('bar=baz')
+      expect(fields['query_string']).to eq('bar=baz')
       expect(fields['request']).to eq('GET /foo?bar=baz ') # env['SERVER_PROTOCOL'] is not set under rack-test
     end
 


### PR DESCRIPTION
This will prevent colliding with the logstasher `parameters` key, which is actually the Rails params hash, and not the query string.
