### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.0.1
 
 - *Changes logging format* to drop the "@fields" prefix and rename "@tags" to "tags".
 - Updates development dependencies

--- a/lib/rack/logstasher/version.rb
+++ b/lib/rack/logstasher/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module Logstasher
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
The log format changes, but this doesn't break anything in the app so calling
this a patch update.

Logstasher did a patch version for the equivalent change (1.2.0 to 1.2.1)
so I think this is fine.