### PR TITLE
Fix error when Rack uses system monotonic clock & release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Fix logging error where Rack uses the system monotonic clock.
+
 # 1.0.1
 
 - *Changes logging format* to drop the "@fields" prefix and rename "@tags" to "tags".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# unreleased
+# 1.0.2
 
 - Fix logging error where Rack uses the system monotonic clock.
 

--- a/lib/rack/logstasher/logger.rb
+++ b/lib/rack/logstasher/logger.rb
@@ -13,7 +13,7 @@ module Rack
       private
 
       def log(env, status, response_headers, began_at)
-        now = Time.now
+        now = Utils.clock_time
 
         data = {
           :method => env["REQUEST_METHOD"],

--- a/lib/rack/logstasher/version.rb
+++ b/lib/rack/logstasher/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module Logstasher
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
We use Time.now, Rack uses Utils.clock_time.  Utils.clock_time uses
Process.clock_gettime if the monotonic clock is supported, and
Time.now otherwise.

Change our code to also use Utils.clock_time, to avoid this error:

```
irb(main):003:0> (Time.now - Process.clock_gettime(Process::CLOCK_MONOTONIC)) * 1000
Traceback (most recent call last):
        4: from /usr/lib/rbenv/versions/2.6.5/bin/irb:23:in `<main>'
        3: from /usr/lib/rbenv/versions/2.6.5/bin/irb:23:in `load'
        2: from /usr/lib/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        1: from (irb):3
NoMethodError (undefined method `*' for 2020-01-08 00:00:22 +0000:Time)
```

Subtracting two times or two clock values is fine:

```
irb(main):005:0> then_ = Time.now
=> 2020-01-15 13:30:14 +0000
irb(main):006:0> now_ = Time.now
=> 2020-01-15 13:30:18 +0000
irb(main):007:0> (now_ - then_) * 1000
=> 3752.65999
```

```
irb(main):008:0> then_ = Process.clock_gettime(Process::CLOCK_MONOTONIC)
=> 653417.651781742
irb(main):009:0> now_ = Process.clock_gettime(Process::CLOCK_MONOTONIC)
=> 653424.258738792
irb(main):010:0> (now_ - then_) * 1000
=> 6606.957050040364
```

---

[Trello card](https://trello.com/c/cGJhvKoC/1281-figure-out-why-rack-upgrade-broke-sitemaps-fix-it)