### PR TITLE
Bump to version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.1.0
 
 - Require Ruby 2.7 and greater
 

--- a/lib/rack/logstasher/version.rb
+++ b/lib/rack/logstasher/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module Logstasher
-    VERSION = "1.0.2".freeze
+    VERSION = "1.1.0".freeze
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This only includes the change to require a non-EOL Ruby version for users, though does release some cleanup and verifies the GitHub action release works