### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
+---
 version: 2
 updates:
-  - package-ecosystem: bundler
-    directory: "/"
-    schedule:
-      interval: daily
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: daily
+- package-ecosystem: bundler
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.3 
+* Set dependency cooldowns for Dependabot
+
 # 2.2.2
 
 * Configure CI workflow to handle concurrent releases ([#75](https://github.com/alphagov/rack-logstasher/pull/75))

--- a/lib/rack/logstasher/version.rb
+++ b/lib/rack/logstasher/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module Logstasher
-    VERSION = "2.2.2".freeze
+    VERSION = "2.2.3".freeze
   end
 end


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
